### PR TITLE
"fix" for pytest version 4.1.0 and above. Remove use of pytest.config

### DIFF
--- a/pytest_emoji/plugin.py
+++ b/pytest_emoji/plugin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-
 from pytest_emoji import hooks
 
 
@@ -40,35 +38,40 @@ def pytest_emoji_xpassed(config):
     return u'😲 ', u'XPASS 😲 '
 
 
+def pytest_configure(config):
+    global _config
+    _config = config
+
+
 def pytest_report_teststatus(report):
-    if pytest.config.option.emoji is False:
+    if _config.option.emoji is False:
         # Do not modify reporting unless pytest
         # is called with --emoji
         return
 
-    error_hook = pytest.config.hook.pytest_emoji_error
-    failed_hook = pytest.config.hook.pytest_emoji_failed
-    passed_hook = pytest.config.hook.pytest_emoji_passed
-    skipped_hook = pytest.config.hook.pytest_emoji_skipped
-    xfailed_hook = pytest.config.hook.pytest_emoji_xfailed
-    xpassed_hook = pytest.config.hook.pytest_emoji_xpassed
+    error_hook = _config.hook.pytest_emoji_error
+    failed_hook = _config.hook.pytest_emoji_failed
+    passed_hook = _config.hook.pytest_emoji_passed
+    skipped_hook = _config.hook.pytest_emoji_skipped
+    xfailed_hook = _config.hook.pytest_emoji_xfailed
+    xpassed_hook = _config.hook.pytest_emoji_xpassed
 
     # Handle error and skipped in setup and teardown phase
     if report.when in ('setup', 'teardown'):
         if report.failed:
-            short, verbose = error_hook(config=pytest.config)
+            short, verbose = error_hook(config=_config)
             return 'error', short, verbose
         elif report.skipped:
-            short, verbose = skipped_hook(config=pytest.config)
+            short, verbose = skipped_hook(config=_config)
             return 'skipped', short, verbose
 
     # Handle xfailed and xpassed
     if hasattr(report, 'wasxfail'):
         if report.skipped:
-            short, verbose = xfailed_hook(config=pytest.config)
+            short, verbose = xfailed_hook(config=_config)
             return 'xfailed', short, verbose
         elif report.passed:
-            short, verbose = xpassed_hook(config=pytest.config)
+            short, verbose = xpassed_hook(config=_config)
             return 'xpassed', short, verbose
         else:
             return '', '', ''
@@ -76,11 +79,11 @@ def pytest_report_teststatus(report):
     # Handle passed, skipped and failed in call phase
     if report.when == 'call':
         if report.passed:
-            short, verbose = passed_hook(config=pytest.config)
+            short, verbose = passed_hook(config=_config)
         elif report.skipped:
-            short, verbose = skipped_hook(config=pytest.config)
+            short, verbose = skipped_hook(config=_config)
         elif report.failed:
-            short, verbose = failed_hook(config=pytest.config)
+            short, verbose = failed_hook(config=_config)
         return report.outcome, short, verbose
 
 

--- a/tests/test_emoji.py
+++ b/tests/test_emoji.py
@@ -80,6 +80,7 @@ def test_emoji_disabled_by_default_verbose(testdir, emoji_tests):
     # run pytest with the following cmd args
     result = testdir.runpytest(
         '-v',
+        '-o', 'console_output_style=classic'
     )
 
     # fnmatch_lines does an assertion internally
@@ -106,6 +107,7 @@ def test_emoji_enabled_verbose(testdir, emoji_tests):
     result = testdir.runpytest(
         '-v',
         '--emoji',
+        '-o', 'console_output_style=classic'
     )
 
     # fnmatch_lines does an assertion internally
@@ -134,6 +136,7 @@ def test_emoji_enabled_custom_verbose(testdir, emoji_tests, custom_emojis):
     result = testdir.runpytest(
         '-v',
         '--emoji',
+        '-o', 'console_output_style=classic'
     )
 
     # fnmatch_lines does an assertion internally
@@ -157,7 +160,9 @@ def test_emoji_disabled_by_default_non_verbose(testdir, emoji_tests):
     testdir.makepyfile(emoji_tests)
 
     # run pytest with the following cmd args
-    result = testdir.runpytest()
+    result = testdir.runpytest(
+        '-o', 'console_output_style=classic'
+    )
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
@@ -176,6 +181,7 @@ def test_emoji_enabled_non_verbose(testdir, emoji_tests):
     # run pytest with the following cmd args
     result = testdir.runpytest(
         '--emoji',
+        '-o', 'console_output_style=classic'
     )
 
     # fnmatch_lines does an assertion internally
@@ -197,6 +203,7 @@ def test_emoji_enabled_custom_non_verbose(testdir, emoji_tests, custom_emojis):
     # run pytest with the following cmd args
     result = testdir.runpytest(
         '--emoji',
+        '-o', 'console_output_style=classic'
     )
 
     # fnmatch_lines does an assertion internally

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py33,py34,py35,flake8
+envlist = py33,py34,py35,py36,py37,flake8
 
 [testenv]
+deps = pytest
 commands = pytest {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
Use of `pytest.config` is deprecated, so this plugin generates a lot of warnings.
I'm not thrilled with my solution, but it works.

Used `pytest_configure` hook to save off `config` for use later in `pytest_report_teststatus`.

Also, added `-o console_output_style=classic` to tests so the new percentages didn't cause failures. And bumped tox to include testing up through py37